### PR TITLE
durationLog field added in regionLog

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
             android:value="sample://notif" />
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyDpyEMA0LcerlPYmkewAEhDsbTOPrLQZbs"/>
+            android:value=""/>
     </application>
 
 </manifest>

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
@@ -211,10 +211,10 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
                 val regionDuration = this.db.regionDurationDAO.getRegionDuration(it.identifier)
                 if (regionDuration != null) {
                     regionDuration.exitTime = (System.currentTimeMillis() - regionDuration.entryTime) / 1000 //in sec
-                    it.DurationLog = regionDuration.exitTime
+                    it.spentTime = regionDuration.exitTime
                     this.db.regionDurationDAO.updateRegionDuration(regionDuration)
                 } else {
-                    it.DurationLog = 0
+                    it.spentTime = 0
                 }
             }
         }

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
@@ -181,7 +181,7 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
     }
 
     protected fun saveRegionLogInDataBase(region: Region, isInside: Boolean): RegionLog {
-        val regionLog = RegionLog()
+        var regionLog = RegionLog()
         regionLog.identifier = region.identifier
         regionLog.dateTime = region.dateTime
         regionLog.didEnter = region.didEnter
@@ -195,8 +195,31 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
         } else {
             regionLog.eventName = "woos_geofence_exited_event"
         }
+        regionLog=getRegionLogWithDurationLog(regionLog,isInside)
         this.db.regionLogsDAO.createRegionLog(regionLog)
+        return regionLog
+    }
+    protected fun getRegionLogWithDurationLog(regionLog: RegionLog,isInsideGeofence : Boolean) :RegionLog {
+        regionLog.let {
+            if (isInsideGeofence) {
+                val regionDuration = RegionDuration()
+                regionDuration.regionIdentifier = it.identifier
+                regionDuration.entryTime = System.currentTimeMillis()
+                regionDuration.exitTime=0
+                this.db.regionDurationDAO.createRegionDuration(regionDuration)
+            } else {
+                val regionDuration = this.db.regionDurationDAO.getRegionDuration(it.identifier)
+                if (regionDuration != null) {
+                    regionDuration.exitTime = (System.currentTimeMillis() - regionDuration.entryTime) / 1000 //in sec
+                    it.DurationLog = regionDuration.exitTime
+                    this.db.regionDurationDAO.updateRegionDuration(regionDuration)
+                } else {
+                    it.DurationLog = 0
+                }
+            }
+        }
         return regionLog;
+
     }
 
     fun distanceBetweenLocationAndPosition(position: MovingPosition, location: Location): Float {
@@ -322,6 +345,7 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
                 }else{
                     regionLog.eventName="woos_zoi_classified_exited_event"
                 }
+                regionLog=getRegionLogWithDurationLog(regionLog,didEnter)
                 this.db.regionLogsDAO.createRegionLog(regionLog)
 
                 if (woosmapProvider.regionLogReadyListener != null) {
@@ -980,6 +1004,7 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
         } else {
             regionLog.eventName = "woos_geofence_exited_event"
         }
+        regionLog=getRegionLogWithDurationLog(regionLog,regionDetected.didEnter)
         if (regionDetected.didEnter != regionDetected.isCurrentPositionInside) {
 
             regionLog.isCurrentPositionInside = regionDetected.didEnter

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionDuration.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionDuration.java
@@ -7,7 +7,7 @@ import androidx.room.PrimaryKey;
 public class RegionDuration {
     @PrimaryKey(autoGenerate = true)
     public int id;
-    public int regionID;
+    public String regionIdentifier;
     public long entryTime;
     public long exitTime;
 }

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionDuration.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionDuration.java
@@ -1,0 +1,13 @@
+package com.webgeoservices.woosmapgeofencingcore.database;
+
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+@Entity(tableName = "RegionDuration")
+public class RegionDuration {
+    @PrimaryKey(autoGenerate = true)
+    public int id;
+    public int regionID;
+    public long entryTime;
+    public long exitTime;
+}

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionDurationDAO.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionDurationDAO.java
@@ -1,6 +1,7 @@
 package com.webgeoservices.woosmapgeofencingcore.database;
 
 import androidx.room.Dao;
+import androidx.room.Delete;
 import androidx.room.Insert;
 import androidx.room.Query;
 import androidx.room.Update;
@@ -13,6 +14,12 @@ public interface RegionDurationDAO {
     @Update
     void updateRegionDuration(RegionDuration regionDuration);
 
-    @Query("SELECT * FROM RegionDuration WHERE regionIdentifier like :regionIdentifier")
+    @Delete
+    void deleteRegionDuration(RegionDuration regionDuration);
+
+    @Query("SELECT * FROM RegionDuration WHERE regionIdentifier like :regionIdentifier ORDER BY entryTime DESC LIMIT 1")
     RegionDuration getRegionDuration(String regionIdentifier);
+
+    @Query("DELETE FROM RegionDuration WHERE entryTime <= :dataDurationDelay")
+    void deleteRegionDurationsOlderThan(long dataDurationDelay);
 }

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionDurationDAO.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionDurationDAO.java
@@ -1,0 +1,18 @@
+package com.webgeoservices.woosmapgeofencingcore.database;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.Query;
+import androidx.room.Update;
+
+@Dao
+public interface RegionDurationDAO {
+    @Insert
+    void createRegionDuration(RegionDuration regionDuration);
+
+    @Update
+    void updateRegionDuration(RegionDuration regionDuration);
+
+    @Query("SELECT * FROM RegionDuration WHERE regionID = :regionID")
+    RegionDuration getRegionDuration(int regionID);
+}

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionDurationDAO.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionDurationDAO.java
@@ -13,6 +13,6 @@ public interface RegionDurationDAO {
     @Update
     void updateRegionDuration(RegionDuration regionDuration);
 
-    @Query("SELECT * FROM RegionDuration WHERE regionID = :regionID")
-    RegionDuration getRegionDuration(int regionID);
+    @Query("SELECT * FROM RegionDuration WHERE regionIdentifier like :regionIdentifier")
+    RegionDuration getRegionDuration(String regionIdentifier);
 }

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionLog.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionLog.java
@@ -24,5 +24,5 @@ public class RegionLog {
     public String type = "circle";
     public float expectedAverageSpeed=-1f;
     public String eventName="";
-    public long DurationLog = 0;
+    public long spentTime = 0;
 }

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionLog.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionLog.java
@@ -24,5 +24,5 @@ public class RegionLog {
     public String type = "circle";
     public float expectedAverageSpeed=-1f;
     public String eventName="";
-    public int DurationLog = 0;
+    public long DurationLog = 0;
 }

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionLog.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/RegionLog.java
@@ -24,4 +24,5 @@ public class RegionLog {
     public String type = "circle";
     public float expectedAverageSpeed=-1f;
     public String eventName="";
+    public int DurationLog = 0;
 }

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/WoosmapDb.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/WoosmapDb.java
@@ -13,7 +13,7 @@ import androidx.room.TypeConverters;
 import com.webgeoservices.woosmapgeofencingcore.FigmmForVisitsCreatorCore;
 import com.webgeoservices.woosmapgeofencingcore.WoosmapSettingsCore;
 
-@Database(entities = {Visit.class, MovingPosition.class, POI.class, ZOI.class, Region.class, RegionLog.class, Distance.class}, version = 33, exportSchema = false)
+@Database(entities = {Visit.class, MovingPosition.class, POI.class, ZOI.class, Region.class, RegionLog.class, Distance.class}, version = 34, exportSchema = false)
 @TypeConverters({Converters.class})
 public abstract class WoosmapDb extends RoomDatabase {
 

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/WoosmapDb.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/WoosmapDb.java
@@ -13,7 +13,7 @@ import androidx.room.TypeConverters;
 import com.webgeoservices.woosmapgeofencingcore.FigmmForVisitsCreatorCore;
 import com.webgeoservices.woosmapgeofencingcore.WoosmapSettingsCore;
 
-@Database(entities = {Visit.class, MovingPosition.class, POI.class, ZOI.class, Region.class, RegionLog.class, Distance.class}, version = 34, exportSchema = false)
+@Database(entities = {Visit.class, MovingPosition.class, POI.class, ZOI.class, Region.class, RegionLog.class, Distance.class,RegionDuration.class}, version = 36, exportSchema = false)
 @TypeConverters({Converters.class})
 public abstract class WoosmapDb extends RoomDatabase {
 
@@ -30,6 +30,8 @@ public abstract class WoosmapDb extends RoomDatabase {
     public abstract RegionLogsPAO getRegionLogsDAO();
 
     public abstract DistancesDAO getDistanceDAO();
+
+    public abstract RegionDurationDAO getRegionDurationDAO();
 
     private static volatile WoosmapDb instance;
 

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/WoosmapDb.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/WoosmapDb.java
@@ -13,7 +13,7 @@ import androidx.room.TypeConverters;
 import com.webgeoservices.woosmapgeofencingcore.FigmmForVisitsCreatorCore;
 import com.webgeoservices.woosmapgeofencingcore.WoosmapSettingsCore;
 
-@Database(entities = {Visit.class, MovingPosition.class, POI.class, ZOI.class, Region.class, RegionLog.class, Distance.class,RegionDuration.class}, version = 37, exportSchema = false)
+@Database(entities = {Visit.class, MovingPosition.class, POI.class, ZOI.class, Region.class, RegionLog.class, Distance.class,RegionDuration.class}, version = 38, exportSchema = false)
 @TypeConverters({Converters.class})
 public abstract class WoosmapDb extends RoomDatabase {
 

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/WoosmapDb.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/database/WoosmapDb.java
@@ -13,7 +13,7 @@ import androidx.room.TypeConverters;
 import com.webgeoservices.woosmapgeofencingcore.FigmmForVisitsCreatorCore;
 import com.webgeoservices.woosmapgeofencingcore.WoosmapSettingsCore;
 
-@Database(entities = {Visit.class, MovingPosition.class, POI.class, ZOI.class, Region.class, RegionLog.class, Distance.class,RegionDuration.class}, version = 36, exportSchema = false)
+@Database(entities = {Visit.class, MovingPosition.class, POI.class, ZOI.class, Region.class, RegionLog.class, Distance.class,RegionDuration.class}, version = 37, exportSchema = false)
 @TypeConverters({Converters.class})
 public abstract class WoosmapDb extends RoomDatabase {
 
@@ -68,6 +68,7 @@ public abstract class WoosmapDb extends RoomDatabase {
                 getDistanceDAO().deleteDistanceOlderThan(dateNow - WoosmapSettingsCore.dataDurationDelay);
                 getRegionLogsDAO().deleteRegionLogsOlderThan(dateNow - WoosmapSettingsCore.dataDurationDelay);
                 getRegionsDAO().deleteRegionsOlderThan(dateNow - WoosmapSettingsCore.dataDurationDelay);
+                getRegionDurationDAO().deleteRegionDurationsOlderThan(dateNow - WoosmapSettingsCore.dataDurationDelay);
                 //Update date
                 mPrefs.edit().putLong("lastUpdate", System.currentTimeMillis()).apply();
             }


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

# Description
Time spent within any geofence is recorded as durationLog in regionLog.
## Issue
<!-- Link the PR to one or more issues. -->
<!-- Use "closes" followed by the issue ID. 
closes #314159
-->
Woosmap/geofencing-enterprise-android-sdk#31

## What
<!-- What did you do? (Functionally).
Added this new feature/value, fixed that bug/behaviour…
-->
1.New database table creation `RegionDuration`.
2.Time spend in geofence is captured.

## How
<!-- How did you do it? (Technically).
I used this library to add this to make that better.
-->
1.New database table creation `RegionDuration`.
2.Time spend in geofence is captured.

## Related PRs
<!-- List of possible related PRs against other repos.
<!-- Alternatively, indicate "None".
- [ ] #271828
- [ ] ...
-->

# Testing
## Automated tests
- [ ] Unit Tests cover the change
- [x] Smoke Tests cover the change  

<!-- Notice: if one of the above boxes is not ticked, please explain why. -->

## Steps to test or reproduce
<!-- Command to initiate automated tests.
`bender test`
-->

<!-- Or, list of steps to follow for manual testing.
- Do this
- Do that
- ...
-->

# Deployment
## Strategy
- [x] This is a standard deployment

<!-- Warning: if this box is not ticked, please detail the steps to deploy and TALK TO THE OPS TEAM! -->

## Migrations
<!-- Choose one -->
No.
