### PR TITLE
Replace requests to Traffic by requests to Distance API

### DIFF
--- a/app/src/main/java/com/webgeoservices/samplecore/LocationFragment.java
+++ b/app/src/main/java/com/webgeoservices/samplecore/LocationFragment.java
@@ -67,20 +67,20 @@ public class LocationFragment extends Fragment {
                     listDestinationPoint.add(new Pair(49.987,0.223));*/
                     Double latOrigin = place.getLatitude();
                     Double lngOrigin = place.getLongitude();
-                    mPositionsManager.calculateDistance(latOrigin, lngOrigin, listDestinationPoint, place.getLocationId());
+                    mPositionsManager.calculateDistance(latOrigin, lngOrigin, listDestinationPoint, place.getLocationId(), false);
                     Map<String, String> param = new HashMap<String, String>();
                     param.put( "distanceProvider","woosmapDistance" );
                     param.put( "distanceMode","walking" );
                     param.put( "distanceUnits","imperial" );
                     param.put( "distanceLanguage","en" );
-                    mPositionsManager.calculateDistance(latOrigin, lngOrigin, listDestinationPoint, param, place.getLocationId() );
+                    mPositionsManager.calculateDistance(latOrigin, lngOrigin, listDestinationPoint, param, place.getLocationId(), false);
                     param.put( "distanceProvider","WoosmapTraffic" );
                     param.put( "trafficDistanceRouting","balanced" );
                     param.put( "trafficDistanceMethod","distance" );
                     param.put( "distanceMode","driving" );
                     param.put( "distanceUnits","metric" );
                     param.put( "distanceLanguage","fr" );
-                    mPositionsManager.calculateDistance(latOrigin, lngOrigin, listDestinationPoint, param, place.getLocationId() );
+                    mPositionsManager.calculateDistance(latOrigin, lngOrigin, listDestinationPoint, param, place.getLocationId(), true);
                 }
             }
         });

--- a/app/src/main/java/com/webgeoservices/samplecore/LocationFragment.java
+++ b/app/src/main/java/com/webgeoservices/samplecore/LocationFragment.java
@@ -76,6 +76,7 @@ public class LocationFragment extends Fragment {
                     mPositionsManager.calculateDistance(latOrigin, lngOrigin, listDestinationPoint, param, place.getLocationId() );
                     param.put( "distanceProvider","WoosmapTraffic" );
                     param.put( "trafficDistanceRouting","balanced" );
+                    param.put( "trafficDistanceMethod","distance" );
                     param.put( "distanceMode","driving" );
                     param.put( "distanceUnits","metric" );
                     param.put( "distanceLanguage","fr" );

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_geofence_2.5
+VERSION_NAME=core_beta2.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_beta2.15
+VERSION_NAME=core_geofence_2.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_beta2.13
+VERSION_NAME=core_beta2.14

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_beta2.14
+VERSION_NAME=core_beta2.15

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_beta2.16
+VERSION_NAME=core_beta2.17

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_beta2.17
+VERSION_NAME=core_beta2.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_geofence_2.6
+VERSION_NAME=core_beta2.16

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
@@ -533,7 +533,7 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
         listPosition: MutableList<Pair<Double, Double>>,
         locationId: Int = 0,
     ) {
-        calculateDistance(latOrigin, lngOrigin, listPosition, emptyMap(), locationId, false);
+        calculateDistance(latOrigin, lngOrigin, listPosition, emptyMap(), locationId, WoosmapSettingsCore.distanceWithTraffic);
     }
 
     fun calculateDistance(
@@ -553,7 +553,7 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
         parameters: Map<String, String>,
         locationId: Int = 0,
     ) {
-        calculateDistance(latOrigin, lngOrigin, listPosition, parameters, locationId, false)
+        calculateDistance(latOrigin, lngOrigin, listPosition, parameters, locationId, WoosmapSettingsCore.distanceWithTraffic)
     }
 
     fun calculateDistance(

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
@@ -618,6 +618,17 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
             if (parameters.containsKey("distanceLanguage")) {
                 language = parameters["distanceLanguage"]
             }
+            //Check if params contains old trafficDistanceRouting
+            if (parameters.containsKey("trafficDistanceRouting")) {
+                var value = parameters["trafficDistanceRouting"]
+                if (value.equals(WoosmapSettingsCore.fastest, true)){
+                    method = WoosmapSettingsCore.time;
+                }
+                if (value.equals(WoosmapSettingsCore.balanced, true)){
+                    method = WoosmapSettingsCore.distance;
+                }
+            }
+            //Override method param value if trafficDistanceMethod exists
             if (parameters.containsKey("trafficDistanceMethod")) {
                 method = parameters["trafficDistanceMethod"]
             }

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
@@ -616,7 +616,7 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
         var mode = WoosmapSettingsCore.distanceMode
         var units = WoosmapSettingsCore.distanceUnits
         var language = WoosmapSettingsCore.distanceLanguage
-        var method = WoosmapSettingsCore.trafficDistanceMethod
+        var method = WoosmapSettingsCore.distanceMethod
         if (parameters.isEmpty()) {
             url = String.format(
                 requestUrl,

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
@@ -524,13 +524,15 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
         locationId: Int = 0
     ) {
         if (WoosmapSettingsCore.distanceProvider == WoosmapSettingsCore.woosmapDistance) {
-            distanceAPI(latOrigin, lngOrigin, listPosition, locationId)
+            distanceAPI(latOrigin, lngOrigin, listPosition, locationId, false)
         } else {
-            trafficDistanceAPI(
+            Log.w(WoosmapSettingsCore.WoosmapSdkTag, "Woosmap Traffic API has been deprecated. You are being redirected to Woosmap Distance API.")
+            distanceAPI(
                 latOrigin,
                 lngOrigin,
                 listPosition,
                 locationId,
+                true
             )
         }
     }
@@ -548,13 +550,15 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
         }
 
         if (provider == WoosmapSettingsCore.woosmapDistance) {
-            distanceAPI(latOrigin, lngOrigin, listPosition, locationId, parameters)
+            distanceAPI(latOrigin, lngOrigin, listPosition, locationId, false, parameters)
         } else {
-            trafficDistanceAPI(
+            Log.w(WoosmapSettingsCore.WoosmapSdkTag, "Woosmap Traffic API has been deprecated. You are being redirected to Woosmap Distance API.")
+            distanceAPI(
                 latOrigin,
                 lngOrigin,
                 listPosition,
                 locationId,
+                true,
                 parameters
             )
         }
@@ -566,8 +570,13 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
         lngOrigin: Double,
         listPosition: MutableList<Pair<Double, Double>>,
         locationId: Int = 0,
+        considerTrafic: Boolean = false,
         parameters: Map<String, String> = emptyMap(),
     ) {
+        var requestUrl = WoosmapSettingsCore.DistanceAPIUrl
+        if (considerTrafic){
+            requestUrl = WoosmapSettingsCore.DistanceAPIWithTrafficUrl
+        }
         if (requestQueue == null) {
             requestQueue = Volley.newRequestQueue(this.context)
         }
@@ -587,7 +596,7 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
         var language = WoosmapSettingsCore.distanceLanguage
         if (parameters.isEmpty()) {
             url = String.format(
-                WoosmapSettingsCore.DistanceAPIUrl,
+                requestUrl,
                 WoosmapSettingsCore.WoosmapURL,
                 WoosmapSettingsCore.distanceMode,
                 WoosmapSettingsCore.getDistanceUnits(),
@@ -608,7 +617,7 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
                 language = parameters["distanceLanguage"]
             }
             url = String.format(
-                WoosmapSettingsCore.DistanceAPIUrl,
+                requestUrl,
                 WoosmapSettingsCore.WoosmapURL,
                 mode,
                 units,

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
@@ -570,11 +570,11 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
         lngOrigin: Double,
         listPosition: MutableList<Pair<Double, Double>>,
         locationId: Int = 0,
-        considerTrafic: Boolean = false,
+        distanceWithTraffic: Boolean = false,
         parameters: Map<String, String> = emptyMap(),
     ) {
         var requestUrl = WoosmapSettingsCore.DistanceAPIUrl
-        if (considerTrafic){
+        if (distanceWithTraffic){
             requestUrl = WoosmapSettingsCore.DistanceAPIWithTrafficUrl
         }
         if (requestQueue == null) {
@@ -594,6 +594,7 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
         var mode = WoosmapSettingsCore.distanceMode
         var units = WoosmapSettingsCore.distanceUnits
         var language = WoosmapSettingsCore.distanceLanguage
+        var method = WoosmapSettingsCore.trafficDistanceMethod
         if (parameters.isEmpty()) {
             url = String.format(
                 requestUrl,
@@ -604,7 +605,8 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
                 latOrigin,
                 lngOrigin,
                 destination,
-                WoosmapSettingsCore.privateKeyWoosmapAPI
+                WoosmapSettingsCore.privateKeyWoosmapAPI,
+                method,
             )
         } else {
             if (parameters.containsKey("distanceMode")) {
@@ -616,6 +618,9 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
             if (parameters.containsKey("distanceLanguage")) {
                 language = parameters["distanceLanguage"]
             }
+            if (parameters.containsKey("trafficDistanceMethod")) {
+                method = parameters["trafficDistanceMethod"]
+            }
             url = String.format(
                 requestUrl,
                 WoosmapSettingsCore.WoosmapURL,
@@ -625,7 +630,8 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
                 latOrigin,
                 lngOrigin,
                 destination,
-                WoosmapSettingsCore.privateKeyWoosmapAPI
+                WoosmapSettingsCore.privateKeyWoosmapAPI,
+                method,
             )
         }
         val req = APIHelperCore.getInstance(context).createGetReuqest(
@@ -649,7 +655,7 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
                                     distance.distanceText = element.distance.text
                                     distance.duration = element.duration.value
                                     distance.durationText = element.duration.text
-                                    distance.routing = WoosmapSettingsCore.trafficDistanceRouting
+                                    distance.routing = method
                                     distance.mode = mode
                                     distance.units = units
                                     distance.language = language

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -202,8 +202,25 @@ public class WoosmapSettingsCore {
     static public String distanceMode = drivingMode;
 
     //Distance Provider
+    /***
+     * @deprecated
+     * Setting the value of `distanceProvider` property is now deprecated.
+     * Woosmap Distance API will always be used as the provider.
+     */
+    @Deprecated
     public static final String woosmapDistance = "WoosmapDistance";
+
+    /***
+     * @deprecated
+     * Setting the value of `distanceProvider` property is now deprecated.
+     * Woosmap Distance API will always be used as the provider.
+     */
+    @Deprecated
     public static final String woosmapTraffic = "WoosmapTraffic";
+    /***
+     * @deprecated `distanceProvider` property is now deprecated. Woosmap Distance API will always be used as the provider.
+     */
+    @Deprecated
     static public String distanceProvider = woosmapDistance;
 
     /***
@@ -244,6 +261,13 @@ public class WoosmapSettingsCore {
 
     }
 
+    /***
+     * Setting the distance provider is now deprecated. The SDK will now always use Distance API as distance provider.
+     * The value you set here will be ignored. If you need to get the distance with traffic considerations then pass `distanceWithTraffic` as `true` to
+     * `PositionManagerCore` class' `calculateDistance` method
+     * @param distanceProvider
+     */
+    @Deprecated
     public static void setDistanceProvider(String distanceProvider) {
         if (distanceProvider.equals(woosmapDistance) || distanceProvider.equals(woosmapTraffic)) {
             WoosmapSettingsCore.distanceProvider = distanceProvider;
@@ -290,6 +314,13 @@ public class WoosmapSettingsCore {
         return distanceMode;
     }
 
+    /***
+     * @deprecated Setting the distance provider is now deprecated. The SDK will now always use Distance API as distance provider.
+     * If you need to get the distance with traffic considerations then pass `distanceWithTraffic` as `true` to
+     * `PositionManagerCore` class' `calculateDistance` method.
+     * @return the distane provider service.
+     */
+    @Deprecated
     public static String getDistanceProvider() {
         return distanceProvider;
     }

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -230,12 +230,12 @@ public class WoosmapSettingsCore {
     @Deprecated
     protected static final String fastest = "fastest";
     /***
-     * @deprecated Set `distance` value to `trafficDistanceMethod` setting instead
+     * @deprecated Set `distance` value to `distanceMethod` setting instead
      */
     @Deprecated
     protected static final String balanced = "balanced";
     /***
-     * @deprecated Use `trafficDistanceMethod` instead.
+     * @deprecated Use `distanceMethod` instead.
      */
     @Deprecated
     static public String trafficDistanceRouting = fastest;

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -97,7 +97,7 @@ public class WoosmapSettingsCore {
         WoosmapSettingsCore.distanceMaxAirDistanceFilter = mPrefs.getInt("distanceMaxAirDistanceFilter", WoosmapSettingsCore.distanceMaxAirDistanceFilter);
         WoosmapSettingsCore.distanceAPIEnable = mPrefs.getBoolean("distanceAPIEnable", WoosmapSettingsCore.distanceAPIEnable);
         WoosmapSettingsCore.trafficDistanceRouting = mPrefs.getString("trafficDistanceRouting", WoosmapSettingsCore.trafficDistanceRouting);
-        WoosmapSettingsCore.trafficDistanceMethod = mPrefs.getString("trafficDistanceMethod", WoosmapSettingsCore.trafficDistanceMethod);
+        WoosmapSettingsCore.distanceMethod = mPrefs.getString("trafficDistanceMethod", WoosmapSettingsCore.distanceMethod);
         WoosmapSettingsCore.distanceWithTraffic = mPrefs.getBoolean("trafficDistanceMethod", WoosmapSettingsCore.distanceWithTraffic);
         WoosmapSettingsCore.distanceProvider = mPrefs.getString("distanceProvider", WoosmapSettingsCore.distanceProvider);
         WoosmapSettingsCore.distanceUnits = mPrefs.getString("distanceUnits", WoosmapSettingsCore.distanceUnits);
@@ -243,7 +243,7 @@ public class WoosmapSettingsCore {
     //Disatnce method
     protected static final String time = "time";
     protected static final String distance = "distance";
-    static protected String trafficDistanceMethod = time;
+    static protected String distanceMethod = time;
 
     protected static boolean distanceWithTraffic = false;
 
@@ -292,11 +292,11 @@ public class WoosmapSettingsCore {
         WoosmapSettingsCore.distanceWithTraffic = value;
     }
 
-    public static void setTrafficDistanceMethod(String trafficDistanceMethod) {
-        if (trafficDistanceMethod.equals(time) || trafficDistanceMethod.equals(distance)) {
-            WoosmapSettingsCore.trafficDistanceMethod = trafficDistanceMethod;
+    public static void setDistanceMethod(String distanceMethod) {
+        if (distanceMethod.equals(time) || distanceMethod.equals(distance)) {
+            WoosmapSettingsCore.distanceMethod = distanceMethod;
         } else {
-            WoosmapSettingsCore.trafficDistanceMethod = time;
+            WoosmapSettingsCore.distanceMethod = time;
         }
     }
 
@@ -304,8 +304,8 @@ public class WoosmapSettingsCore {
         return WoosmapSettingsCore.distanceWithTraffic;
     }
 
-    public static String getTrafficDistanceMethod(){
-        return WoosmapSettingsCore.trafficDistanceMethod;
+    public static String getDistanceMethod(){
+        return WoosmapSettingsCore.distanceMethod;
     }
 
     public static void setDistanceLanguage(String distanceLanguage) {

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -98,6 +98,7 @@ public class WoosmapSettingsCore {
         WoosmapSettingsCore.distanceAPIEnable = mPrefs.getBoolean("distanceAPIEnable", WoosmapSettingsCore.distanceAPIEnable);
         WoosmapSettingsCore.trafficDistanceRouting = mPrefs.getString("trafficDistanceRouting", WoosmapSettingsCore.trafficDistanceRouting);
         WoosmapSettingsCore.trafficDistanceMethod = mPrefs.getString("trafficDistanceMethod", WoosmapSettingsCore.trafficDistanceMethod);
+        WoosmapSettingsCore.distanceWithTraffic = mPrefs.getBoolean("trafficDistanceMethod", WoosmapSettingsCore.distanceWithTraffic);
         WoosmapSettingsCore.distanceProvider = mPrefs.getString("distanceProvider", WoosmapSettingsCore.distanceProvider);
         WoosmapSettingsCore.distanceUnits = mPrefs.getString("distanceUnits", WoosmapSettingsCore.distanceUnits);
         WoosmapSettingsCore.distanceLanguage = mPrefs.getString("distanceLanguage", WoosmapSettingsCore.distanceLanguage);
@@ -244,6 +245,8 @@ public class WoosmapSettingsCore {
     protected static final String distance = "distance";
     static protected String trafficDistanceMethod = time;
 
+    protected static boolean distanceWithTraffic = false;
+
     //Distance Language
     static public String distanceLanguage = "en";
 
@@ -285,12 +288,20 @@ public class WoosmapSettingsCore {
         }
     }
 
+    public static void setDistanceWithTraffic(boolean value){
+        WoosmapSettingsCore.distanceWithTraffic = value;
+    }
+
     public static void setTrafficDistanceMethod(String trafficDistanceMethod) {
         if (trafficDistanceMethod.equals(time) || trafficDistanceMethod.equals(distance)) {
             WoosmapSettingsCore.trafficDistanceMethod = trafficDistanceMethod;
         } else {
             WoosmapSettingsCore.trafficDistanceMethod = time;
         }
+    }
+
+    public static boolean getDistanceWithTrafic(){
+        return WoosmapSettingsCore.distanceWithTraffic;
     }
 
     public static String getTrafficDistanceMethod(){

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -300,7 +300,7 @@ public class WoosmapSettingsCore {
         }
     }
 
-    public static boolean getDistanceWithTrafic(){
+    public static boolean getDistanceWithTraffic(){
         return WoosmapSettingsCore.distanceWithTraffic;
     }
 

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -326,6 +326,7 @@ public class WoosmapSettingsCore {
     public static String WoosmapURL = "https://api.woosmap.com";
     public static String SearchAPIUrl = "%s/stores/search/?private_key=%s&lat=%s&lng=%s&stores_by_page=20";
     public static String DistanceAPIUrl = "%s/distance/distancematrix/json?mode=%s&units=%s&language=%s&origins=%s,%s&destinations=%s&private_key=%s&elements=duration_distance";
+    public static String DistanceAPIWithTrafficUrl = "%s/distance/distancematrix/json?mode=%s&units=%s&language=%s&origins=%s,%s&destinations=%s&private_key=%s&departure_time=now&elements=duration_distance";
     public static String TrafficDistanceAPIUrl = "%s/traffic/distancematrix/json?mode=%s&units=%s&language=%s&routing=%s&origins=%s,%s&destinations=%s&private_key=%s";
     public static String GoogleMapStaticUrl = "https://maps.google.com/maps/api/staticmap?markers=color:red%%7C%s,%s&markers=color:blue%%7C%s,%s&zoom=14&size=400x400&sensor=true&key=%s";
     public static String GoogleMapStaticUrl1POI = "https://maps.google.com/maps/api/staticmap?markers=color:red%%7C%s,%s&zoom=14&size=400x400&sensor=true&key=%s";

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -41,6 +41,8 @@ public class WoosmapSettingsCore {
         prefsEditor.putString("distanceMode", distanceMode);
         prefsEditor.putString("trafficDistanceRouting", trafficDistanceRouting);
         prefsEditor.putString("distanceProvider", distanceProvider);
+        prefsEditor.putString("distanceMethod", distanceMethod);
+        prefsEditor.putBoolean("distanceWithTraffic", distanceWithTraffic);
         prefsEditor.putString("distanceUnits", distanceUnits);
         prefsEditor.putString("distanceLanguage", distanceLanguage);
         prefsEditor.putInt("accuracyFilter", accuracyFilter);
@@ -97,8 +99,8 @@ public class WoosmapSettingsCore {
         WoosmapSettingsCore.distanceMaxAirDistanceFilter = mPrefs.getInt("distanceMaxAirDistanceFilter", WoosmapSettingsCore.distanceMaxAirDistanceFilter);
         WoosmapSettingsCore.distanceAPIEnable = mPrefs.getBoolean("distanceAPIEnable", WoosmapSettingsCore.distanceAPIEnable);
         WoosmapSettingsCore.trafficDistanceRouting = mPrefs.getString("trafficDistanceRouting", WoosmapSettingsCore.trafficDistanceRouting);
-        WoosmapSettingsCore.distanceMethod = mPrefs.getString("trafficDistanceMethod", WoosmapSettingsCore.distanceMethod);
-        WoosmapSettingsCore.distanceWithTraffic = mPrefs.getBoolean("trafficDistanceMethod", WoosmapSettingsCore.distanceWithTraffic);
+        WoosmapSettingsCore.distanceMethod = mPrefs.getString("distanceMethod", WoosmapSettingsCore.distanceMethod);
+        WoosmapSettingsCore.distanceWithTraffic = mPrefs.getBoolean("distanceWithTraffic", WoosmapSettingsCore.distanceWithTraffic);
         WoosmapSettingsCore.distanceProvider = mPrefs.getString("distanceProvider", WoosmapSettingsCore.distanceProvider);
         WoosmapSettingsCore.distanceUnits = mPrefs.getString("distanceUnits", WoosmapSettingsCore.distanceUnits);
         WoosmapSettingsCore.distanceLanguage = mPrefs.getString("distanceLanguage", WoosmapSettingsCore.distanceLanguage);

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -97,6 +97,7 @@ public class WoosmapSettingsCore {
         WoosmapSettingsCore.distanceMaxAirDistanceFilter = mPrefs.getInt("distanceMaxAirDistanceFilter", WoosmapSettingsCore.distanceMaxAirDistanceFilter);
         WoosmapSettingsCore.distanceAPIEnable = mPrefs.getBoolean("distanceAPIEnable", WoosmapSettingsCore.distanceAPIEnable);
         WoosmapSettingsCore.trafficDistanceRouting = mPrefs.getString("trafficDistanceRouting", WoosmapSettingsCore.trafficDistanceRouting);
+        WoosmapSettingsCore.trafficDistanceMethod = mPrefs.getString("trafficDistanceMethod", WoosmapSettingsCore.trafficDistanceMethod);
         WoosmapSettingsCore.distanceProvider = mPrefs.getString("distanceProvider", WoosmapSettingsCore.distanceProvider);
         WoosmapSettingsCore.distanceUnits = mPrefs.getString("distanceUnits", WoosmapSettingsCore.distanceUnits);
         WoosmapSettingsCore.distanceLanguage = mPrefs.getString("distanceLanguage", WoosmapSettingsCore.distanceLanguage);
@@ -210,6 +211,11 @@ public class WoosmapSettingsCore {
     private static final String balanced = "balanced";
     static public String trafficDistanceRouting = fastest;
 
+    //Disatnce method
+    private static final String time = "time";
+    private static final String distance = "distance";
+    static public String trafficDistanceMethod = time;
+
     //Distance Language
     static public String distanceLanguage = "en";
 
@@ -240,6 +246,14 @@ public class WoosmapSettingsCore {
             WoosmapSettingsCore.trafficDistanceRouting = trafficDistanceRouting;
         } else {
             WoosmapSettingsCore.trafficDistanceRouting = fastest;
+        }
+    }
+
+    public static void setTrafficDistanceMethod(String trafficDistanceMethod) {
+        if (trafficDistanceMethod.equals(time) || trafficDistanceMethod.equals(distance)) {
+            WoosmapSettingsCore.trafficDistanceMethod = trafficDistanceMethod;
+        } else {
+            WoosmapSettingsCore.trafficDistanceMethod = time;
         }
     }
 
@@ -325,8 +339,8 @@ public class WoosmapSettingsCore {
 
     public static String WoosmapURL = "https://api.woosmap.com";
     public static String SearchAPIUrl = "%s/stores/search/?private_key=%s&lat=%s&lng=%s&stores_by_page=20";
-    public static String DistanceAPIUrl = "%s/distance/distancematrix/json?mode=%s&units=%s&language=%s&origins=%s,%s&destinations=%s&private_key=%s&elements=duration_distance";
-    public static String DistanceAPIWithTrafficUrl = "%s/distance/distancematrix/json?mode=%s&units=%s&language=%s&origins=%s,%s&destinations=%s&private_key=%s&departure_time=now&elements=duration_distance";
+    public static String DistanceAPIUrl = "%s/distance/distancematrix/json?mode=%s&units=%s&language=%s&origins=%s,%s&destinations=%s&private_key=%s&method=%s&elements=duration_distance";
+    public static String DistanceAPIWithTrafficUrl = "%s/distance/distancematrix/json?mode=%s&units=%s&language=%s&origins=%s,%s&destinations=%s&private_key=%s&method=%s&departure_time=now&elements=duration_distance";
     public static String TrafficDistanceAPIUrl = "%s/traffic/distancematrix/json?mode=%s&units=%s&language=%s&routing=%s&origins=%s,%s&destinations=%s&private_key=%s";
     public static String GoogleMapStaticUrl = "https://maps.google.com/maps/api/staticmap?markers=color:red%%7C%s,%s&markers=color:blue%%7C%s,%s&zoom=14&size=400x400&sensor=true&key=%s";
     public static String GoogleMapStaticUrl1POI = "https://maps.google.com/maps/api/staticmap?markers=color:red%%7C%s,%s&zoom=14&size=400x400&sensor=true&key=%s";

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -206,15 +206,26 @@ public class WoosmapSettingsCore {
     public static final String woosmapTraffic = "WoosmapTraffic";
     static public String distanceProvider = woosmapDistance;
 
-    //Distance Routing
-    private static final String fastest = "fastest";
-    private static final String balanced = "balanced";
+    /***
+     * @deprecated Set `time` value to `trafficDistanceMethod` setting instead
+     */
+    @Deprecated
+    protected static final String fastest = "fastest";
+    /***
+     * @deprecated Set `distance` value to `trafficDistanceMethod` setting instead
+     */
+    @Deprecated
+    protected static final String balanced = "balanced";
+    /***
+     * @deprecated Use `trafficDistanceMethod` instead.
+     */
+    @Deprecated
     static public String trafficDistanceRouting = fastest;
 
     //Disatnce method
-    private static final String time = "time";
-    private static final String distance = "distance";
-    static public String trafficDistanceMethod = time;
+    protected static final String time = "time";
+    protected static final String distance = "distance";
+    static protected String trafficDistanceMethod = time;
 
     //Distance Language
     static public String distanceLanguage = "en";
@@ -241,6 +252,7 @@ public class WoosmapSettingsCore {
         }
     }
 
+    @Deprecated
     public static void setTrafficDistanceRouting(String trafficDistanceRouting) {
         if (trafficDistanceRouting.equals(fastest) || trafficDistanceRouting.equals(balanced)) {
             WoosmapSettingsCore.trafficDistanceRouting = trafficDistanceRouting;
@@ -255,6 +267,10 @@ public class WoosmapSettingsCore {
         } else {
             WoosmapSettingsCore.trafficDistanceMethod = time;
         }
+    }
+
+    public static String getTrafficDistanceMethod(){
+        return WoosmapSettingsCore.trafficDistanceMethod;
     }
 
     public static void setDistanceLanguage(String distanceLanguage) {


### PR DESCRIPTION
# Description
## Issue
closes #9 
closes Woosmap/woosmap/issues/1066

## What
Stop request to Traffic API and replace them by Distance API requests with proper parameters.

## How
1. Added additional parameter `considerTrafic` in `distanceAPI` of `PositionManager` class. 
2. If `considerTrafic` is `true` then add additional parameter `departure_time` (value is set to `now`) to distance API.

## Related PRs
None

# Testing
## Automated tests
- [ ] Unit Tests cover the change
- [ ] Smoke Tests cover the change  
- [x] Manual Tests cover the change  


## Steps to test or reproduce

# Deployment
## Strategy
- [x] This is a standard deployment


## Migrations
<!-- Choose one -->
No.
