### PR TITLE
Add `X-Android-Fingerprint` header in the API requests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_geofence_2.8
+VERSION_NAME=core_geofence_2.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_geofence_2.8
+VERSION_NAME=core_beta2.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_beta2.26
+VERSION_NAME=core_geofence_2.8

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/APIHelperCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/APIHelperCore.java
@@ -35,11 +35,15 @@ public class APIHelperCore {
             @Override
             public Map<String, String> getHeaders() throws AuthFailureError {
                 Map<String, String> headers = new ArrayMap<>();
+                String sha1Hash = WoosmapSettingsCore.getSHA1CertificateHash(context);
                 headers.put("X-Api-Key", WoosmapSettingsCore.privateKeyWoosmapAPI);
                 headers.put("X-Android-Identifier", context.getPackageName());
                 headers.put("X-SDK-Source", "geofence-sdk");
                 headers.put("X-AK-SDK-Platform", "Android");
                 headers.put("X-AK-SDK-Version", WoosmapSettingsCore.getGeofencingSDKVersion());
+                if (sha1Hash != null){
+                    headers.put("X-Android-Fingerprint", sha1Hash);
+                }
                 return headers;
             }
         };

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -6,7 +6,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.pm.Signature;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -15,6 +17,14 @@ import com.google.android.gms.location.GeofencingEvent;
 import com.google.gson.Gson;
 import com.webgeoservices.woosmapgeofencingcore.database.WoosmapDb;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -446,6 +456,59 @@ public class WoosmapSettingsCore {
             return GeofencingSDKVersion;
         }
         return BuildConfig.CORE_SDK_VERSION;
+    }
+
+    protected static String getSHA1CertificateHash(Context context){
+        PackageManager pm = context.getPackageManager();
+        String packageName = context.getPackageName();
+        int flags = PackageManager.GET_SIGNATURES;
+        PackageInfo packageInfo = null;
+        try {
+            packageInfo = pm.getPackageInfo(packageName, flags);
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
+        Signature[] signatures = packageInfo.signatures;
+        byte[] cert = signatures[0].toByteArray();
+        InputStream input = new ByteArrayInputStream(cert);
+        CertificateFactory cf = null;
+        try {
+            cf = CertificateFactory.getInstance("X509");
+        } catch (CertificateException e) {
+            e.printStackTrace();
+        }
+
+        X509Certificate c = null;
+        try {
+            c = (X509Certificate) cf.generateCertificate(input);
+        } catch (CertificateException e) {
+            e.printStackTrace();
+        }
+
+        String hexString = null;
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA1");
+            byte[] publicKey = md.digest(c.getEncoded());
+            hexString = byte2HexFormatted(publicKey);
+        } catch (NoSuchAlgorithmException e1) {
+            e1.printStackTrace();
+        } catch (CertificateEncodingException e) {
+            e.printStackTrace();
+        }
+        return hexString;
+    }
+
+    private static String byte2HexFormatted(byte[] arr) {
+        StringBuilder str = new StringBuilder(arr.length * 2);
+        for (int i = 0; i < arr.length; i++) {
+            String h = Integer.toHexString(arr[i]);
+            int l = h.length();
+            if (l == 1) h = "0" + h;
+            if (l > 2) h = h.substring(l - 2, l);
+            str.append(h.toUpperCase());
+            if (i < (arr.length - 1)) str.append(':');
+        }
+        return str.toString();
     }
 
 }

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -499,8 +499,10 @@ public class WoosmapSettingsCore {
         } catch (CertificateEncodingException e) {
             e.printStackTrace();
         }
-        SHA1CertificateHash = hexString;
-        return SHA1CertificateHash;
+        if (hexString!=null){
+            SHA1CertificateHash = hexString;
+        }
+        return hexString;
     }
 
     private static String byte2HexFormatted(byte[] arr) {

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -458,7 +458,11 @@ public class WoosmapSettingsCore {
         return BuildConfig.CORE_SDK_VERSION;
     }
 
+    private static String SHA1CertificateHash = "";
     protected static String getSHA1CertificateHash(Context context){
+        if (!SHA1CertificateHash.isEmpty()){
+            return SHA1CertificateHash;
+        }
         PackageManager pm = context.getPackageManager();
         String packageName = context.getPackageName();
         int flags = PackageManager.GET_SIGNATURES;
@@ -495,7 +499,8 @@ public class WoosmapSettingsCore {
         } catch (CertificateEncodingException e) {
             e.printStackTrace();
         }
-        return hexString;
+        SHA1CertificateHash = hexString;
+        return SHA1CertificateHash;
     }
 
     private static String byte2HexFormatted(byte[] arr) {


### PR DESCRIPTION

## Issue
closes https://github.com/Woosmap/geofencing-enterprise-android-sdk/issues/81

## Describe your changes
1. Added `X-Android-Fingerprint` header in each API request and sending SHA1 cert fingerprint in it.

## How to test
1. Create an Android only private key on Woosmap Console.
2. Use the key in the sample app and run the app.

## Checklist:

- [x] My code follows the style guidelines for this repo
- [x] I have performed a self-review of my code
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings/errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

## Comments
<!-- Any other comments... maybe a linked PR or note to remember something -->
