### PR TITLE
Fix - broken distance api call and default value of `enableDistanceAPI` parameter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_beta2.33
+VERSION_NAME=core_beta2.34

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_geofence_2.12
+VERSION_NAME=core_beta2.33

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_beta2.34
+VERSION_NAME=core_geofence_2.13

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
@@ -445,7 +445,8 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
             positon.lat,
             positon.lng,
             destination,
-            WoosmapSettingsCore.privateKeyWoosmapAPI
+            WoosmapSettingsCore.privateKeyWoosmapAPI,
+            WoosmapSettingsCore.getDistanceMethod(),
         )
         Logger.getInstance().d("Calling Distance API: $url")
         val req = APIHelperCore.getInstance(context).createGetReuqest(

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/WoosmapSettingsCore.java
@@ -205,7 +205,7 @@ public class WoosmapSettingsCore {
 
 
     //Enable/disable DistanceAPI
-    static public boolean distanceAPIEnable = true;
+    static public boolean distanceAPIEnable = false;
 
 
     //Mode transportation DistanceAPI


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

## Issue
closes #25 
closes #26 
closes https://github.com/Woosmap/geofencing-enterprise-android-sdk/issues/104

## Describe your changes
1. [default value of distanceAPIEnable to false](https://github.com/Woosmap/geofencing-core-android-sdk/commit/ae624d26c9c250b5319c11601731d4f3a2c4473b)
2. [added missing method parameter in distance matrix API call in requestDistanceAPI method of PositionManagerCore](https://github.com/Woosmap/geofencing-core-android-sdk/commit/cd3e009eb1364d296abd380818c4b69d5dfdd2c0)

## How to test
Issue can be tested in enterprise SDK. Refer https://github.com/Woosmap/geofencing-enterprise-android-sdk/issues/104

## Checklist:
<!-- Please go through this list. Don't just tick the boxes, verify each one. -->

- [x] My code follows the style guidelines for this repo
- [x] I have performed a self-review of my code
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings/errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

## Comments
<!-- Any other comments... maybe a linked PR or note to remember something -->
