### PR TITLE
Fix `didEnter` flag value

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,1 @@
-- Bug fix: Address parsing throws exception when `lines` attribute in an asset is a string instead of an array
-- Upgraded `minSdk` version to 26
+- Bug fix: Fix `didEnter` flag value

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_beta2.49
+VERSION_NAME=core_geofence_2.18.1
 android.nonFinalResIds=false
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_geofence_2.18.1
+VERSION_NAME=core_beta2.49
 android.nonFinalResIds=false
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_geofence_2.18.2
+VERSION_NAME=core_geofence_2.18.3
 android.nonFinalResIds=false
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_geofence_2.18.1
+VERSION_NAME=core_geofence_2.18.2
 android.nonFinalResIds=false
 

--- a/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
+++ b/woosmapgeofencingcore/src/main/java/com/webgeoservices/woosmapgeofencingcore/PositionsManagerCore.kt
@@ -196,7 +196,7 @@ open class PositionsManagerCore(context: Context, db: WoosmapDb, woosmapProvider
         var regionLog = RegionLog()
         regionLog.identifier = region.identifier
         regionLog.dateTime = region.dateTime
-        regionLog.didEnter = region.didEnter
+        regionLog.didEnter = isInside
         regionLog.lat = region.lat
         regionLog.lng = region.lng
         regionLog.idStore = region.idStore


### PR DESCRIPTION
## Issue
closes https://github.com/Woosmap/geofencing-enterprise-android-sdk/issues/150

## Describe your changes
* Fixed `didEnter` flag value in `RegionLogReady` callback

## How to test
* Observe RegionLogReady callback and verify that `didEnter` is `true` on region entry and `false` on region exit

## Checklist:
<!-- Please go through this list. Don't just tick the boxes, verify each one. -->

- [x] My code follows the style guidelines for this repo
- [ ] ~My code passes the SonarCloud check and does not add new code smells~
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings/errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

### Documentation
N/A

### Libs/SDKs
N/A
