### PR TITLE
chore: add Dependabot config for Gradle and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Gradle: root project plus the :app and :woosmapgeofencingcore modules
+  - package-ecosystem: "gradle"
+    directories:
+      - "/"
+      - "/app"
+      - "/woosmapgeofencingcore"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      # Batch low-risk minor/patch bumps into a single PR to cut noise;
+      # major bumps stay as individual PRs for manual review.
+      gradle-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by deploy.yml and version_checker.yml
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Issue
N/A — proactive supply-chain hardening. (Companion to a separate discussion about enabling Dependabot across the Android geofencing SDKs.)

## Describe your changes
Adds `.github/dependabot.yml` enabling weekly Dependabot **version updates**:

- **Gradle** — covers the root project plus the `:app` and `:woosmapgeofencingcore` modules (all three `build.gradle` files). Minor/patch bumps are grouped into a single PR; major bumps stay separate for manual review.
- **GitHub Actions** — covers the actions used in `deploy.yml` and `version_checker.yml`, grouped into one PR.

`open-pull-requests-limit` and grouping are set to keep PR noise low. Note: Dependabot **vulnerability alerts** are already enabled on this repo; this adds the version-update layer. Automated **security-fix PRs** are a separate repo Settings toggle (not file-based) — recommend enabling it too.

## How to test
1. Merge to `master`.
2. Repo **Insights → Dependency graph → Dependabot** should list two ecosystems (gradle, github-actions).
3. Within ~24h (or via **"Check for updates"**), Dependabot opens grouped PRs for any available updates.
4. Confirm grouped minor/patch Gradle PRs and a single grouped Actions PR appear, labelled `dependencies`.

## Checklist:
- [x] My code follows the style guidelines for this repo
- [x] My code passes the SonarCloud check and does not add new code smells
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings/errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

> Note: config-only change, no tests applicable. The `dependencies` label is referenced; create it in repo Settings if it doesn't exist (Dependabot will create it on first PR otherwise).

### Documentation
N/A

### Libs/SDKs
N/A