### PR TITLE
fix(deps): restore Kotlin 1.9.x consumer compatibility (#58)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,15 +5,18 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        // AGP 9 provides built-in Kotlin support; the standalone
-        // 'org.jetbrains.kotlin.android' plugin is removed. Pin the Kotlin
-        // Gradle Plugin to 2.4.0 so built-in Kotlin uses the intended version.
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0'
+        // Pinned to AGP 8.13.x + the standalone Kotlin Gradle Plugin 1.9.23.
+        // AGP 8's standalone Kotlin compiler stamps the AAR with Kotlin 1.9
+        // metadata, keeping core consumable by Kotlin 1.9.x consumers AND 2.4.0
+        // ones (newer compilers read older metadata) (issue #58). AGP 9's
+        // built-in kotlinc ignores this pin and always emits 2.x metadata.
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23'
     }
 }
 plugins {
-    id 'com.android.application' version '9.2.1' apply false
-    id 'com.android.library' version '9.2.1' apply false
+    id 'com.android.application' version '8.13.0' apply false
+    id 'com.android.library' version '8.13.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
     id "org.owasp.dependencycheck" version "12.2.2"
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- Restored Kotlin 1.9.x consumer compatibility: reverted toolchain to AGP 8.13.0 / Gradle 8.13 / Kotlin 1.9.23 so the AAR is stamped with Kotlin 1.9 metadata (readable by both 1.9.x and 2.4.0 consumers). Kept ojalgo 56.2.1, guava 33.6.0-jre, `androidx.annotation`, and compileSdk/targetSdk 36 (issue #58).
 - Fixed JitPack publishing on Gradle 9 / AGP 9 (explicit `maven-publish` + `jitpack.yml`)
 - Upgraded toolchain: AGP 8.3.0 → 9.2.1, Gradle 8.9 → 9.5.1, Kotlin 1.9.0 → 2.4.0, compileSdk 35 → 36
 - Upgraded dependencies: ojalgo 56.2.1, play-services-maps 20.0.0, android-maps-utils 4.4.0, gson 2.14.0, guava 33.6.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,5 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-VERSION_NAME=core_geofence_2.18.4
+VERSION_NAME=core_geofence_2.18.5
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,3 @@
-# Pin the JDK JitPack uses to build this tag. Gradle 9.5.1 / AGP 9 require JDK 17+.
+# Pin the JDK JitPack uses to build this tag. AGP 8.13 / Gradle 8.13 require JDK 17+.
 jdk:
   - openjdk17

--- a/woosmapgeofencingcore/build.gradle
+++ b/woosmapgeofencingcore/build.gradle
@@ -1,5 +1,9 @@
 plugins {
     id 'com.android.library'
+    // AGP 8 has no built-in Kotlin support, so the standalone Kotlin Android
+    // plugin (1.9.23, pinned in the root build.gradle) compiles the single
+    // .kt file and stamps it with Kotlin 1.9 metadata (issue #58).
+    id 'org.jetbrains.kotlin.android'
     // Self-contained publishing. JitPack used to auto-inject maven-publish, but
     // that injection no longer registers publishToMavenLocal on Gradle 9 / AGP 9.
     id 'maven-publish'
@@ -34,6 +38,9 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
     }
     namespace 'com.webgeoservices.woosmapgeofencingcore'
 


### PR DESCRIPTION
Closes #58.

## Problem
PR #54 bumped the toolchain to **AGP 9.2.1 / Gradle 9.5.1 / Kotlin 2.4.0**. AGP 9's built-in kotlinc stamps Kotlin **2.x `@Metadata`** into the AAR, which a K1 **1.9.x** compiler refuses to read (*"compiled with a newer version of Kotlin"*). This propagates through the enterprise SDK's `api` re-export and breaks consumers still on Kotlin 1.9.x (Woosmap/geofencing-react-native-plugin#211, customer: Burger King).

## Why not just pin Kotlin under AGP 9
Tried first, per discussion. Pinning `kotlin-gradle-plugin:1.9.23` while keeping AGP 9.2.1 **builds green but does not fix the metadata** — AGP 9's *built-in* kotlinc ignores the classpath pin and still emits `@Metadata mv=[2,0]`, which 1.9.x still rejects. AGP 9 cannot produce a 1.9-metadata artifact.

## Fix
Revert the toolchain so the standalone Kotlin compiler emits 1.9 metadata:
- **AGP** `9.2.1 → 8.13.0`
- **Gradle** `9.5.1 → 8.13`
- Restore standalone **`org.jetbrains.kotlin.android` `1.9.23`** plugin (AGP 8 has no built-in Kotlin)
- `kotlinOptions { jvmTarget = '17' }`
- Bump core version → **`core_geofence_2.18.5`**

**Kept** all substantive PR #54 upgrades: **ojalgo 56.2.1**, **guava 33.6.0-jre**, the `javax.annotation → androidx.annotation` change, and **compileSdk/targetSdk 36**.

A 1.9-level artifact is the lowest common denominator — the same AAR is consumable by **both** Kotlin 1.9.x and 2.4.0 consumers (newer compilers read older metadata).

## Verification
- ✅ `./gradlew clean assembleDebug assembleRelease testDebugUnitTest` green (AGP 8.13 / Gradle 8.13 / JDK 17)
- ✅ Compiled `PositionsManagerCore.class` `@Metadata mv=[1,9,0]` (was `2.x`)
- ✅ `publishToMavenLocal` (JitPack `-Pgroup`/`-Pversion` path) green; **published AAR confirmed `mv=[1,9,0]`**

## Sequencing
Per #58, this lands **first**. The enterprise SDK (Woosmap/geofencing-enterprise-android-sdk) must then bump its `api 'com.github.Woosmap:geofencing-core-android-sdk:core_geofence_2.18.5'` coordinate once this is published.

Refs: Woosmap/geofencing-react-native-plugin#211, PR #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)